### PR TITLE
Change feedback options

### DIFF
--- a/content-images/wai-statements/statements.css
+++ b/content-images/wai-statements/statements.css
@@ -69,6 +69,17 @@ width: auto;
   padding: 0.5rem;
 }
 
+
+/* Preview */
+#accstatement .feedback.other-contact-methods
+{
+  margin-top: 0;
+  margin-left: 0;
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+}
+
 #accstatement #accstmnt_standard_other_name
 {
   display: none;

--- a/content-images/wai-statements/statements.js
+++ b/content-images/wai-statements/statements.js
@@ -187,7 +187,10 @@ var page = {
 
     // statement: feedback
     (function() {
-      var items = document.querySelectorAll('#accstatement #form-feedback input:not(#accstmnt_contact_responsetime)');
+      var items = document.querySelectorAll(
+        '#accstatement #form-feedback input:not(#accstmnt_contact_responsetime)'
+        + ', #accstatement #form-feedback textarea'
+      );
       var list = result.querySelector('#statement-feedback');
       var html = '';
 
@@ -198,6 +201,8 @@ var page = {
             html += '<a href="mailto:'+items[i].value+'">'+items[i].value+'</a>';
           } else if(items[i].getAttribute('type') === 'url') {
             html += '<a href="'+items[i].value+'">'+items[i].value+'</a>';
+          } else if (items[i].nodeName === 'TEXTAREA') {
+            html += '<pre class="feedback other-contact-methods">' + items[i].value + '</pre>';
           } else {
             html += items[i].value;
           }

--- a/generator.html
+++ b/generator.html
@@ -145,10 +145,6 @@ external_css: /content-images/wai-statements/statements.css
                 <label for="accstmnt_contact_write">Write us at</label>
                 <input type="text" id="accstmnt_contact_write" placeholder="PO Box 1, 234 Example Ville, Earth" />
               </div>
-              <div class="field line">
-                <label for="accstmnt_contact_social">Twitter at</label>
-                <input type="url" id="accstmnt_contact_social" placeholder="Example: @CitylightsIncBAD" />
-              </div>
 
               <div class="field proto">
                   <label for="accstmnt_feedback_other_contact_[n]">Contact [n]</label>

--- a/generator.html
+++ b/generator.html
@@ -145,6 +145,12 @@ external_css: /content-images/wai-statements/statements.css
                 <label for="accstmnt_contact_write">Write us at</label>
                 <input type="text" id="accstmnt_contact_write" placeholder="PO Box 1, 234 Example Ville, Earth" />
               </div>
+
+              <div class="field">
+                <label for="accstmnt_contact_other">Other contact options</label>
+                <textarea id="accstmnt_contact_other"></textarea>
+              </div>
+
               <div class="field">
                 <label for="accstmnt_contact_responsetime">Typical duration for response</label>
                 <input type="text" id="accstmnt_contact_responsetime" placeholder="Example: 2 work days" />

--- a/generator.html
+++ b/generator.html
@@ -129,29 +129,22 @@ external_css: /content-images/wai-statements/statements.css
 
             <fieldset class="group" id="form-feedback">
               <legend class="visuallyhidden">Feedback</legend>
-              <div class="field line">
+              <div class="field">
                 <label for="accstmnt_contact_phone">Phone us at</label>
                 <input type="tel" id="accstmnt_contact_phone" placeholder="Example: +12 34 567 89 00" />
               </div>
-              <div class="field line">
+              <div class="field">
                 <label for="accstmnt_contact_email">E-mail us at</label>
                 <input type="email" id="accstmnt_contact_email" placeholder="citylights@example.org" />
               </div>
-              <div class="field line">
+              <div class="field">
                 <label for="accstmnt_contact_visit">Visit us at</label>
                 <input type="text" id="accstmnt_contact_visit" placeholder="Main Street 1, 234 Example Ville, Earth" />
               </div>
-              <div class="field line">
+              <div class="field">
                 <label for="accstmnt_contact_write">Write us at</label>
                 <input type="text" id="accstmnt_contact_write" placeholder="PO Box 1, 234 Example Ville, Earth" />
               </div>
-
-              <div class="field proto">
-                  <label for="accstmnt_feedback_other_contact_[n]">Contact [n]</label>
-                  <input type="text" id="accstmnt_feedback_other_contact_[n]" placeholder="Example: Facebook: www.facebook.com/CitylightsInc" />
-              </div>
-              <button type="button" class="add-line">Add contact</button>
-
               <div class="field">
                 <label for="accstmnt_contact_responsetime">Typical duration for response</label>
                 <input type="text" id="accstmnt_contact_responsetime" placeholder="Example: 2 work days" />


### PR DESCRIPTION
The red "invalid" border around email field are caused by firefox' own stylesheet. To fix this a style overwrite on `:invalid` selector is required inside the form-elements.css stylesheet.

Done:

- Remove twitter field.
- Replace "Add contact" button with a "Other contact options" textarea and made sure the output is reflected as preformatted text in the preview.