### PR TITLE
update compatibility add environment button

### DIFF
--- a/generator.html
+++ b/generator.html
@@ -327,10 +327,13 @@ external_css: /content-images/wai-statements/statements.css
             <label for="accstmnt_asstech_2">Environment 2</label>
             <input type="text" id="accstmnt_asstech_2" placeholder="Example: Browser M with Assistive Technology N" />
           </div>
-          <div class="field line">
-            <label for="accstmnt_asstech_3">Environment 3</label>
-            <input type="text" id="accstmnt_asstech_3" placeholder="Example: Browser X with Assistive Technology Y" />
+
+          <div class="field proto">
+            <label for="accstmnt_asstech_[n]">Environment [n]</label>
+            <input type="text" id="accstmnt_asstech_[n]" />
           </div>
+
+          <button class="add-line" type="button">Add environment</button>
         </fieldset>
 
         <h3 class="label">Known incompatibility <button type="button" class="button-small info-open" aria-expanded="false" aria-controls="support_incompatible"><span>i</span></button></h3>

--- a/generator.html
+++ b/generator.html
@@ -323,10 +323,6 @@ external_css: /content-images/wai-statements/statements.css
             <label for="accstmnt_asstech_1">Environment 1</label>
             <input type="text" id="accstmnt_asstech_1" placeholder="Example: Browser A with Assistive Technology B" />
           </div>
-          <div class="field line">
-            <label for="accstmnt_asstech_2">Environment 2</label>
-            <input type="text" id="accstmnt_asstech_2" placeholder="Example: Browser M with Assistive Technology N" />
-          </div>
 
           <div class="field proto">
             <label for="accstmnt_asstech_[n]">Environment [n]</label>

--- a/generator.html
+++ b/generator.html
@@ -329,7 +329,7 @@ external_css: /content-images/wai-statements/statements.css
             <input type="text" id="accstmnt_asstech_[n]" />
           </div>
 
-          <button class="add-line" type="button">Add environment</button>
+          <button class="add-line" type="button">Add compatible environment</button>
         </fieldset>
 
         <h3 class="label">Known incompatibility <button type="button" class="button-small info-open" aria-expanded="false" aria-controls="support_incompatible"><span>i</span></button></h3>
@@ -353,7 +353,7 @@ external_css: /content-images/wai-statements/statements.css
           </div>
 
           <button type="button" class="add-line">
-            Add environment
+            Add incompatible environment
           </button>
         </fieldset>
 


### PR DESCRIPTION
Re add the removed "Add environment" button and renamed "Add compatible environment"
Removed default spots 2 + 3. They can be added with button.