### PR TITLE
HOTFIX; Create a new Map and chain with set is not supported IE11

### DIFF
--- a/content-images/wai-statements/statements.js
+++ b/content-images/wai-statements/statements.js
@@ -21,8 +21,8 @@
 
     var _formElement = document.forms.create_accessibility_statement_form;
 
-    var _formState = new Map()
-      .set('changed', false);
+    var _formState = new Map();
+    _formState.set('changed', false);
 
     // Do initial form data storage (defaultvalues)
     function _init() {


### PR DESCRIPTION
Creating a new Map object and chain with set is not supported by IE11; e.g. like: `mymap = new Map().set(key, value)`