### PR TITLE
HOTFIX; IE11 Remove focus before removal

### DIFF
--- a/content-images/wai-statements/statements.js
+++ b/content-images/wai-statements/statements.js
@@ -272,6 +272,9 @@
       // Add, click and remove
       document.body.appendChild(a);
       a.click();
+
+      // Release focus before removing
+      a.blur();
       document.body.removeChild(a);
       a = null;
 


### PR DESCRIPTION
The download button works buggy on IE11 / Edge

Removed focus from download link before removing the link