### PR TITLE
Update generator; Make other standard applied visible

### DIFF
--- a/generator.html
+++ b/generator.html
@@ -96,7 +96,7 @@ external_css: /content-images/wai-statements/generator.css
                         <div class="radio-field">
                             <input type="radio" name="accstmnt_standard" id="accstmnt_standard_other" value="Other"/>
                             <label for="accstmnt_standard_other">Other</label>
-                            <input aria-label="Other standard name" type="text" name="accstmnt_standard_other" id="accstmnt_standard_other_name">
+                            <input aria-label="Other standard name" type="text" id="accstmnt_standard_other_name">
                         </div>
                     </fieldset>
                 </div>
@@ -643,7 +643,10 @@ external_css: /content-images/wai-statements/generator.css
                     is
                     <span class="basic-information conformance-status" data-print="accstmnt_conformance" data-printfilter="lowercase"></span>
                     with
-                    <span class="basic-information conformance-standard" data-print="accstmnt_standard"></span>.
+                    <span class="basic-information conformance-standard">
+                        <span data-print="accstmnt_standard" data-if="accstmnt_standard_other_name" data-negate></span>
+                        <span data-print="accstmnt_standard_other_name" data-if="accstmnt_standard_other_name"></span>.
+                    </span>
                     <span data-if="accstmnt_conformance_meaning">
                         <span class="basic-information conformance-status" data-print="accstmnt_conformance"></span>
                         means that


### PR DESCRIPTION
When choosing an other standard at "Accessibility standards applied" it would not show the input given at other. Now it will.