### PR TITLE
Fixed `mailto:` href issue #160 and links not being links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ _site
 .jekyll-metadata
 .DS_Store
 .netlify
+vendor
+.bundle

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,10 +119,11 @@ GEM
       jekyll (>= 3.6, < 5.0)
 
 PLATFORMS
+  universal-darwin-20
   x86_64-linux
 
 DEPENDENCIES
   wai-gems!
 
 BUNDLED WITH
-   2.2.15
+   2.2.27

--- a/content-images/wai-statements/generator.js
+++ b/content-images/wai-statements/generator.js
@@ -549,13 +549,16 @@
 
       if (dataList && nodeName === 'UL' || nodeName === 'OL') {
         item.innerHTML = printData
-          .map(function wrapInLi(data, index) {
-
-            if (index === 0) {
-              return '\n\t<li>' + data + '</li>\n';
+          .map(function makeElement(data) {
+            // check if starts with "http"
+            const isLink = String(data).startsWith('http');
+            
+            // make it a link is true
+            if(isLink) {
+              return '\n\t<li><a href="' + data + '">' + data + '</a></li>';
             }
 
-            return '\t<li>' + data + '</li>\n';
+            return '\n\t<li>' + data + '</li>\n';
           })
           .join('');
       } else {

--- a/content-images/wai-statements/generator.js
+++ b/content-images/wai-statements/generator.js
@@ -552,12 +552,11 @@
           .map(function makeElement(data) {
             // check if starts with "http"
             const isLink = String(data).startsWith('http');
-            
-            // make it a link is true
+            // make it a link if true
             if(isLink) {
               return '\n\t<li><a href="' + data + '">' + data + '</a></li>';
             }
-
+            // else return as li element
             return '\n\t<li>' + data + '</li>\n';
           })
           .join('');

--- a/content-images/wai-statements/generator.js
+++ b/content-images/wai-statements/generator.js
@@ -1,3 +1,4 @@
+//@ts-nocheck
 /**
  * ACCESSIBILITY STATEMENT GENERATOR
  * ---
@@ -557,13 +558,12 @@
             return '\t<li>' + data + '</li>\n';
           })
           .join('');
-
       } else {
-
         switch (nodeName) {
           case 'A':
-            var hrefPrefix = item.getAttribute('href');
-
+            // checks item for data-href-prefix, prepends to href if it exists
+            var hrefPrefix = item.dataset.hrefPrefix || '';
+            
             item.setAttribute('href', hrefPrefix + printData);
             item.innerText = printData;
             break;

--- a/content/generator_layout.html
+++ b/content/generator_layout.html
@@ -751,7 +751,7 @@
                     </li>
                     <li data-if="accstmnt_contact_email">
                         {{ page.basic_info.feedback.email.title }}:
-                        <a class="email u-email" href="mailto:" data-print="accstmnt_contact_email"></a>
+                        <a class="email u-email" href="mailto:" data-href-prefix="mailto:" data-print="accstmnt_contact_email"></a>
                     </li>
                     <li data-if="accstmnt_contact_visit">
                         {{ page.basic_info.feedback.visitor_address.title }}:


### PR DESCRIPTION
Fixed issue #160 where opening the preview screen more than once would repeatedly append the link to the `href` value.

Also fixed an issue where dynamic inputs (inputs with a 'add another' button) could not be links, specifically referring to the "Other evidence" section. It now auto-detects if it's a link and makes it an anchor element accordingly.